### PR TITLE
Support multiple package managers in setup api, update api version, seamlessApiClient error returned data fix

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/api-types",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "monday.com API types",
   "types": "generated/api-types.d.ts",
   "scripts": {

--- a/packages/api/CHANGELOG.MD
+++ b/packages/api/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Changelog
 
+## [12.0.0]
+
+### ⚠️ Breaking Changes
+
+- **Default API version updated**: The default API version is now `2025-10`
+
 ## [11.1.0]
 
 ### Fixed

--- a/packages/api/CHANGELOG.MD
+++ b/packages/api/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Changelog
 
+## [11.1.0]
+
+### Fixed
+
+- **SeamlessApiClient partial data on errors**: Fixed an issue where `SeamlessApiClientError` did not include partially resolved `data` when GraphQL returned both errors and partial data. The error's `response` object now includes `errors`, `data`, and `extensions` properties (including `requestId`). ([#80](https://github.com/mondaycom/monday-graphql-api/issues/80))
+
 ## [11.0.0]
 
 ### ⚠️ Breaking Changes

--- a/packages/api/lib/constants/index.ts
+++ b/packages/api/lib/constants/index.ts
@@ -4,7 +4,7 @@ export enum AvailableVersions {
   CURRENT = 'current',
   RELEASE_CANDIDATE = 'release_candidate',
   DEV = 'dev',
-  CURRENT_VERSION = '2025-07',
+  CURRENT_VERSION = '2025-10',
 }
 
 export const MONDAY_API_ENDPOINT = 'https://api.monday.com/v2';

--- a/packages/api/lib/errors/seamless-api-client-error.ts
+++ b/packages/api/lib/errors/seamless-api-client-error.ts
@@ -1,10 +1,10 @@
 export class SeamlessApiClientError extends Error {
-  response: { errors: any };
+  response: { errors: any; data?: any; extensions?: any };
   type: string;
 
-  constructor(message: string, errors: any) {
+  constructor(message: string, errors: any, data?: any, extensions?: any) {
     super(message);
-    this.response = { errors };
+    this.response = { errors, data, extensions };
     this.name = this.constructor.name;
     this.type = 'SeamlessApiClientError';
   }

--- a/packages/api/lib/seamless-api-client.ts
+++ b/packages/api/lib/seamless-api-client.ts
@@ -68,7 +68,13 @@ export class SeamlessApiClient {
         clearTimeout(timeoutId);
         removeListener();
         if (data.errorMessage) {
-          const error = new SeamlessApiClientError(data.errorMessage, data.data?.errors);
+          // Include errors, partial data, and extensions in the error response
+          const error = new SeamlessApiClientError(
+            data.errorMessage,
+            data.data?.errors,
+            data.data?.data,
+            data.data?.extensions,
+          );
           reject(error);
         } else {
           resolve(data as T);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/api",
-  "version": "11.0.2",
+  "version": "12.0.0",
   "description": "monday.com API client",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/setup-api/CHANGELOG.MD
+++ b/packages/setup-api/CHANGELOG.MD
@@ -1,0 +1,13 @@
+# Changelog
+
+## [2.1.0]
+
+### Added
+
+- **Multi-package manager support**: Added support for pnpm, bun, and deno in addition to npm and yarn. The CLI now automatically detects the package manager used in your project by examining lock files and the `packageManager` field in `package.json`.
+
+### Changed
+
+- **Automatic package manager detection**: Replaced manual yarn/npm detection with the `package-manager-detector` library for more robust and comprehensive package manager support.
+- **Dynamic install commands**: Install commands are now dynamically generated based on the detected package manager (e.g., `pnpm add`, `bun add`, `yarn add`, `npm install`).
+- **Dynamic run scripts**: The `fetch:generate` script in `package.json` now uses the appropriate run command for the detected package manager (e.g., `pnpm run`, `bun run`, `yarn run`, `npm run`).

--- a/packages/setup-api/jest.config.ts
+++ b/packages/setup-api/jest.config.ts
@@ -4,6 +4,11 @@ const config: Config.InitialOptions = {
   verbose: true,
   testEnvironment: 'node',
   preset: 'ts-jest',
+  // Mock ESM modules from package-manager-detector since Jest can't parse them
+  moduleNameMapper: {
+    '^package-manager-detector/detect$': '<rootDir>/tests/__mocks__/package-manager-detector/detect.ts',
+    '^package-manager-detector/commands$': '<rootDir>/tests/__mocks__/package-manager-detector/commands.ts',
+  },
 };
 
 export default config;

--- a/packages/setup-api/lib/index.ts
+++ b/packages/setup-api/lib/index.ts
@@ -20,6 +20,11 @@ const detectPackageManager = async (): Promise<DetectResult> => {
   return cachedPm;
 };
 
+// Exported for testing purposes only
+export const _resetCache = () => {
+  cachedPm = undefined;
+};
+
 const getRunScriptCommand = (pm: DetectResult | null, scriptName: string): string => {
   if (!pm) {
     return `npm run ${scriptName}`;

--- a/packages/setup-api/lib/index.ts
+++ b/packages/setup-api/lib/index.ts
@@ -2,28 +2,79 @@
 
 import * as shell from 'shelljs';
 import * as fs from 'fs';
+import { detect } from 'package-manager-detector/detect';
+import { resolveCommand } from 'package-manager-detector/commands';
 
-const isYarn = fs.existsSync('yarn.lock');
 const GRAPHQL_REQUEST = 'graphql-request@6.1.0';
 const GRAPHQL = 'graphql@16.8.2';
 
-const installCommands = isYarn
-  ? [
-      `yarn add ${GRAPHQL_REQUEST} ${GRAPHQL}`,
-      'yarn add -D @graphql-codegen/cli@^5.0.5 @graphql-codegen/client-preset@^4.8.0',
-    ]
-  : [
+type DetectResult = Awaited<ReturnType<typeof detect>>;
+
+let cachedPm: DetectResult | undefined;
+
+const detectPackageManager = async (): Promise<DetectResult> => {
+  if (cachedPm !== undefined) {
+    return cachedPm;
+  }
+  cachedPm = await detect();
+  return cachedPm;
+};
+
+const getRunScriptCommand = (pm: DetectResult | null, scriptName: string): string => {
+  if (!pm) {
+    return `npm run ${scriptName}`;
+  }
+  const runCmd = resolveCommand(pm.agent, 'run', [scriptName]);
+  if (!runCmd) {
+    return `npm run ${scriptName}`;
+  }
+  return `${runCmd.command} ${runCmd.args.join(' ')}`;
+};
+
+const getInstallCommands = async (): Promise<string[]> => {
+  const pm = await detectPackageManager();
+
+  if (!pm) {
+    console.warn('Could not detect package manager, falling back to npm');
+    return [
       `npm install ${GRAPHQL_REQUEST} ${GRAPHQL}`,
       'npm install --save-dev @graphql-codegen/cli@^5.0.5 @graphql-codegen/client-preset@^4.8.0',
     ];
+  }
 
-export const installPackages = () => {
-  installCommands.forEach((command) => {
+  console.log(`Detected package manager: ${pm.agent}`);
+
+  // Install production dependencies
+  const prodCmd = resolveCommand(pm.agent, 'add', [GRAPHQL_REQUEST, GRAPHQL]);
+  if (!prodCmd) {
+    throw new Error(`Could not resolve add command for ${pm.agent}`);
+  }
+  const prodCommand = `${prodCmd.command} ${prodCmd.args.join(' ')}`;
+
+  // Install dev dependencies
+  const devCmd = resolveCommand(pm.agent, 'add', [
+    '-D',
+    '@graphql-codegen/cli@^5.0.5',
+    '@graphql-codegen/client-preset@^4.8.0',
+  ]);
+  if (!devCmd) {
+    throw new Error(`Could not resolve add command for ${pm.agent}`);
+  }
+  const devCommand = `${devCmd.command} ${devCmd.args.join(' ')}`;
+
+  return [prodCommand, devCommand];
+};
+
+export const installPackages = async () => {
+  const installCommands = await getInstallCommands();
+
+  for (const command of installCommands) {
+    console.log(`Executing: ${command}`);
     if (shell.exec(command).code !== 0) {
       console.error(`Error executing command: ${command}`);
       shell.exit(1);
     }
-  });
+  }
 
   console.log('Packages installed');
 };
@@ -86,31 +137,40 @@ export const exampleMutation = gql\`
   console.log('Fetch schema script created');
 };
 
-export const updatePackageJsonScripts = () => {
+export const updatePackageJsonScripts = async () => {
   const packageJsonPath = './package.json';
   if (!fs.existsSync(packageJsonPath)) {
     console.error('package.json not found!');
     return;
   }
 
+  const pm = await detectPackageManager();
+
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   packageJson.scripts = packageJson.scripts || {};
   packageJson.scripts['fetch:schema'] = 'bash fetch-schema.sh';
   packageJson.scripts['codegen'] = 'graphql-codegen';
-  packageJson.scripts['fetch:generate'] = 'npm run fetch:schema && npm run codegen';
+  packageJson.scripts['fetch:generate'] =
+    `${getRunScriptCommand(pm, 'fetch:schema')} && ${getRunScriptCommand(pm, 'codegen')}`;
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
   console.log('Updated package.json with new scripts');
 };
 
-export const setupGraphQL = () => {
-  installPackages();
+export const setupGraphQL = async () => {
+  await installPackages();
   createFiles();
-  updatePackageJsonScripts();
-  console.log('Setup complete! run `npm run fetch:generate` to fetch the schema and generate types');
+  await updatePackageJsonScripts();
+  const pm = await detectPackageManager();
+  console.log(
+    `Setup complete! run \`${getRunScriptCommand(pm, 'fetch:generate')}\` to fetch the schema and generate types`,
+  );
 };
 
 // Check if running directly from CLI and not imported
 if (require.main === module) {
-  setupGraphQL();
+  setupGraphQL().catch((error) => {
+    console.error('Setup failed:', error);
+    process.exit(1);
+  });
 }

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.4.0",
+  "version": "2.1.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/setup-api/package.json
+++ b/packages/setup-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/setup-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "monday.com setup api cli",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
@@ -27,6 +27,7 @@
     "url": "https://github.com/mondaycom/monday-graphql-api/tree/main/packages/setup-api"
   },
   "dependencies": {
+    "package-manager-detector": "^1.6.0",
     "shelljs": "^0.8.5"
   },
   "devDependencies": {
@@ -38,14 +39,14 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^16.0.0",
     "@types/shelljs": "^0.8.15",
+    "eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "prettier": "^3.2.4",
     "rollup": "^2.79.1",
     "rollup-plugin-preserve-shebang": "^1.0.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^4.9.5",
-    "eslint": "^8.56.0",
-    "prettier": "^3.2.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/setup-api/tests/__mocks__/package-manager-detector/commands.ts
+++ b/packages/setup-api/tests/__mocks__/package-manager-detector/commands.ts
@@ -1,0 +1,1 @@
+export const resolveCommand = jest.fn().mockReturnValue(null);

--- a/packages/setup-api/tests/__mocks__/package-manager-detector/detect.ts
+++ b/packages/setup-api/tests/__mocks__/package-manager-detector/detect.ts
@@ -1,0 +1,1 @@
+export const detect = jest.fn().mockResolvedValue(null);

--- a/packages/setup-api/tests/setup-graphql.test.ts
+++ b/packages/setup-api/tests/setup-graphql.test.ts
@@ -1,11 +1,8 @@
-import { createFiles, installPackages, updatePackageJsonScripts } from '../lib/index'; // Adjust the import path as necessary
+import { createFiles, installPackages, updatePackageJsonScripts, _resetCache } from '../lib/index';
 import * as shell from 'shelljs';
 import * as fs from 'fs';
-
-const useYarn = shell.which('yarn');
-const packageManager = useYarn ? 'yarn' : 'npm';
-const installCommand = useYarn ? 'add' : 'install';
-const devFlag = useYarn ? '-D' : '--save-dev';
+import { detect } from 'package-manager-detector/detect';
+import { resolveCommand } from 'package-manager-detector/commands';
 
 jest.mock('shelljs', () => ({
   exec: jest.fn().mockReturnValue({ code: 0 }),
@@ -17,27 +14,34 @@ jest.mock('shelljs', () => ({
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   writeFileSync: jest.fn(),
-  existsSync: jest.fn().mockReturnValue(true),
+  existsSync: jest.fn().mockReturnValue(true), // package.json exists
   readFileSync: jest.fn().mockReturnValue(JSON.stringify({})),
 }));
 
-describe('setupGraphQL', () => {
+// Mocks are provided by moduleNameMapper in jest.config.ts
+const mockedDetect = detect as jest.MockedFunction<typeof detect>;
+const mockedResolveCommand = resolveCommand as jest.MockedFunction<typeof resolveCommand>;
+
+describe('setupGraphQL with npm fallback', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    _resetCache(); // Reset the cached package manager detection
+    // Mock no package manager detected (fallback to npm)
+    mockedDetect.mockResolvedValue(null);
+    mockedResolveCommand.mockReturnValue(null);
   });
 
-  it('should install the necessary packages with appropriate package manager', () => {
-    installPackages();
+  it('should install the necessary packages with npm when no package manager detected', async () => {
+    await installPackages();
 
-    expect(shell.exec).toHaveBeenCalledWith(
-      expect.stringContaining(`${packageManager} ${installCommand} graphql-request`),
-    );
+    expect(shell.exec).toHaveBeenCalledWith(expect.stringContaining('npm install graphql-request'));
     expect(shell.exec).toHaveBeenCalledWith(
       expect.stringContaining(
-        `${packageManager} ${installCommand} ${devFlag} @graphql-codegen/cli@^5.0.5 @graphql-codegen/client-preset@^4.8.0`,
+        'npm install --save-dev @graphql-codegen/cli@^5.0.5 @graphql-codegen/client-preset@^4.8.0',
       ),
     );
   });
+
   it('should create necessary files', () => {
     createFiles();
     expect(fs.writeFileSync).toHaveBeenCalledWith('codegen.yml', expect.any(String));
@@ -51,13 +55,46 @@ describe('setupGraphQL', () => {
     });
   });
 
-  it('should add correct scripts to package.json', () => {
-    updatePackageJsonScripts();
+  it('should add correct scripts to package.json with npm when no package manager detected', async () => {
+    await updatePackageJsonScripts();
     const writtenContent = JSON.parse(
       (fs.writeFileSync as jest.Mock).mock.calls.find((call) => call[0] === './package.json')[1],
     );
     expect(writtenContent.scripts['fetch:schema']).toEqual('bash fetch-schema.sh');
     expect(writtenContent.scripts['codegen']).toEqual('graphql-codegen');
     expect(writtenContent.scripts['fetch:generate']).toEqual('npm run fetch:schema && npm run codegen');
+  });
+});
+
+describe('setupGraphQL with pnpm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetCache(); // Reset the cached package manager detection
+    // Mock pnpm detection
+    mockedDetect.mockResolvedValue({ agent: 'pnpm', name: 'pnpm', version: '8.0.0' });
+    mockedResolveCommand.mockImplementation((agent, cmd, args) => {
+      if (cmd === 'add') {
+        return { command: 'pnpm', args: ['add', ...args] };
+      }
+      if (cmd === 'run') {
+        return { command: 'pnpm', args: ['run', ...args] };
+      }
+      return null;
+    });
+  });
+
+  it('should install packages with pnpm', async () => {
+    await installPackages();
+
+    expect(shell.exec).toHaveBeenCalledWith(expect.stringContaining('pnpm add graphql-request'));
+    expect(shell.exec).toHaveBeenCalledWith(expect.stringContaining('pnpm add -D @graphql-codegen/cli'));
+  });
+
+  it('should add correct scripts with pnpm run', async () => {
+    await updatePackageJsonScripts();
+    const writtenContent = JSON.parse(
+      (fs.writeFileSync as jest.Mock).mock.calls.find((call) => call[0] === './package.json')[1],
+    );
+    expect(writtenContent.scripts['fetch:generate']).toEqual('pnpm run fetch:schema && pnpm run codegen');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,11 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-manager-detector@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
1.[ Add more support to different installers (bun, pnpm...) ](https://github.com/mondaycom/monday-graphql-api/issues/77)
2. SeamlessApiClient: no partially resolved data #80 
3. Update api version