### PR TITLE
fix(deps): remove deprecated punycode warning by removing node-fetch

### DIFF
--- a/packages/api/lib/api-client.ts
+++ b/packages/api/lib/api-client.ts
@@ -1,9 +1,9 @@
 import { GraphQLClient, ClientError } from 'graphql-request';
+import type { GraphQLClientResponse, RequestConfig } from 'graphql-request/build/legacy/helpers/types';
 import { ApiVersionType, DEFAULT_VERSION, QueryVariables } from './constants/index';
 import { Sdk, getSdk } from './generated/sdk';
 import pkg from '../package.json';
 import { getApiEndpoint } from './shared/get-api-endpoint';
-import { GraphQLClientResponse, RequestConfig } from 'graphql-request/build/esm/types';
 import z from 'zod';
 
 export { ClientError };

--- a/packages/api/lib/generated/sdk.ts
+++ b/packages/api/lib/generated/sdk.ts
@@ -1,6 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
-import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
+type GraphQLClientRequestHeaders = HeadersInit;
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "graphql": "16.8.2",
-    "graphql-request": "^6.1.0",
+    "graphql-request": "^7.4.0",
     "graphql-tag": "^2.12.6",
     "zod": "3.24.4"
   },
@@ -47,7 +47,6 @@
     "@types/node": "^20.11.18",
     "jest": "^29.7.0",
     "moment": "^2.30.1",
-    "nock": "^13.5.0",
     "rollup": "^2.79.1",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-dts": "^4.2.3",

--- a/packages/api/tests/api-client.integration.test.ts
+++ b/packages/api/tests/api-client.integration.test.ts
@@ -1,46 +1,56 @@
-import nock from 'nock';
 import { ApiClient } from '../lib/api-client';
-import { MONDAY_API_ENDPOINT } from '../lib/constants';
+import type { RequestConfig } from 'graphql-request/build/legacy/helpers/types';
+
+const createFetchMock = (responseData: unknown, delayMs = 0): NonNullable<RequestConfig['fetch']> => {
+  return async (_input: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
+    return new Promise<Response>((resolve, reject) => {
+      const abortSignal = init?.signal;
+      const abortError = () => new DOMException('The user aborted a request.', 'AbortError');
+
+      if (abortSignal?.aborted) {
+        reject(abortError());
+        return;
+      }
+
+      const timeoutId = setTimeout(() => {
+        resolve(
+          new Response(JSON.stringify({ data: responseData }), {
+            status: 200,
+            headers: { 'content-type': 'application/graphql-response+json' },
+          }),
+        );
+      }, delayMs);
+
+      abortSignal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timeoutId);
+          reject(abortError());
+        },
+        { once: true },
+      );
+    });
+  };
+};
 
 describe('ApiClient timeout integration', () => {
-  beforeAll(() => {
-    nock.disableNetConnect();
-  });
-
-  afterEach(() => {
-    // Cancel any pending requests
-    nock.abortPendingRequests();
-    // Clean mock interceptors
-    nock.cleanAll();
-  });
-
-  afterAll(() => {
-    // Restore http module to original implementation (affected by importing nock)
-    nock.restore();
-    // Re-enable real network connections
-    nock.enableNetConnect();
-  });
 
   describe('request method', () => {
     it('should abort request when timeout is exceeded', async () => {
-      nock(MONDAY_API_ENDPOINT)
-        .post('')
-        .delay(2000)
-        .reply(200, { data: { users: [] } });
-
-      const apiClient = new ApiClient({ token: 'test-token' });
+      const apiClient = new ApiClient({
+        token: 'test-token',
+        requestConfig: { fetch: createFetchMock({ users: [] }, 2000) },
+      });
       const query = '{ users { id } }';
 
       await expect(apiClient.request(query, undefined, { timeout: 100 })).rejects.toThrow('The user aborted a request.');
     });
 
     it('should complete successfully when response arrives before timeout', async () => {
-      nock(MONDAY_API_ENDPOINT)
-        .post('')
-        .delay(50)
-        .reply(200, { data: { users: [{ id: '1' }] } });
-
-      const apiClient = new ApiClient({ token: 'test-token' });
+      const apiClient = new ApiClient({
+        token: 'test-token',
+        requestConfig: { fetch: createFetchMock({ users: [{ id: '1' }] }, 50) },
+      });
       const query = '{ users { id } }';
 
       const result = await apiClient.request(query, undefined, { timeout: 500 });
@@ -48,11 +58,10 @@ describe('ApiClient timeout integration', () => {
     });
 
     it('should work without timeout option', async () => {
-      nock(MONDAY_API_ENDPOINT)
-        .post('')
-        .reply(200, { data: { users: [{ id: '1', name: 'John' }] } });
-
-      const apiClient = new ApiClient({ token: 'test-token' });
+      const apiClient = new ApiClient({
+        token: 'test-token',
+        requestConfig: { fetch: createFetchMock({ users: [{ id: '1', name: 'John' }] }) },
+      });
       const query = '{ users { id name } }';
 
       const result = await apiClient.request(query);
@@ -62,24 +71,20 @@ describe('ApiClient timeout integration', () => {
 
   describe('rawRequest method', () => {
     it('should abort rawRequest when timeout is exceeded', async () => {
-      nock(MONDAY_API_ENDPOINT)
-        .post('')
-        .delay(2000)
-        .reply(200, { data: { users: [] } });
-
-      const apiClient = new ApiClient({ token: 'test-token' });
+      const apiClient = new ApiClient({
+        token: 'test-token',
+        requestConfig: { fetch: createFetchMock({ users: [] }, 2000) },
+      });
       const query = '{ users { id } }';
 
       await expect(apiClient.rawRequest(query, undefined, { timeout: 100 })).rejects.toThrow('The user aborted a request.');
     });
 
     it('should complete rawRequest successfully when response arrives before timeout', async () => {
-      nock(MONDAY_API_ENDPOINT)
-        .post('')
-        .delay(50)
-        .reply(200, { data: { users: [{ id: '1' }] } });
-
-      const apiClient = new ApiClient({ token: 'test-token' });
+      const apiClient = new ApiClient({
+        token: 'test-token',
+        requestConfig: { fetch: createFetchMock({ users: [{ id: '1' }] }, 50) },
+      });
       const query = '{ users { id } }';
 
       const result = await apiClient.rawRequest(query, undefined, { timeout: 500 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,13 +1258,6 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.5:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
-  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
-  dependencies:
-    node-fetch "^2.7.0"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -1716,13 +1709,12 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-graphql-request@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz#f4eb2107967af3c7a5907eb3131c671eac89be4f"
-  integrity sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==
+graphql-request@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-7.4.0.tgz#97a1fc871e79f682d816963446ac6b7f99c963f9"
+  integrity sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.2.0"
-    cross-fetch "^3.1.5"
 
 graphql-tag@^2.12.6:
   version "2.12.6"
@@ -2353,11 +2345,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-safe@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
-
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -2522,22 +2509,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-nock@^13.5.0:
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.6.tgz#5e693ec2300bbf603b61dae6df0225673e6c4997"
-  integrity sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==
-  dependencies:
-    debug "^4.1.0"
-    json-stringify-safe "^5.0.1"
-    propagate "^2.0.0"
-
-node-fetch@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -2727,11 +2698,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
-
-propagate@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
-  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -3064,11 +3030,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 ts-api-utils@^2.0.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
@@ -3238,19 +3199,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Upgrade graphql-request to v7.4.0 to eliminate the transitive node-fetch dependency that was causing punycode deprecation warnings. This addresses the deprecation warnings users were seeing in Node.js 21+.