### PR TITLE
Fix ClientError native ESM import

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,14 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "LICENSE"

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -19,6 +19,11 @@ const mainConfig = {
       format: 'es',
       sourcemap: true,
     },
+    {
+      file: 'dist/esm/index.mjs',
+      format: 'es',
+      sourcemap: true,
+    },
   ],
   plugins: [
     del({ targets: 'dist/*' }),


### PR DESCRIPTION
## Summary

- add conditional package exports for `@mondaydotcomorg/api`
- route native Node ESM imports to an `.mjs` build output, while keeping the existing `.js` ESM bundle and CJS entry
- expose `./package.json` through the exports map

Fixes #89.

## Verification

- `corepack yarn install --frozen-lockfile`
- `corepack yarn workspace @mondaydotcomorg/api build`
- `npx -y node@18 --input-type=module -e "import { ClientError } from '@mondaydotcomorg/api'; console.log(ClientError.name);"`
- `node --input-type=module -e "import { ClientError } from '@mondaydotcomorg/api'; console.log(ClientError.name);"`
- `node -e "const { ClientError } = require('@mondaydotcomorg/api'); console.log(ClientError.name);"`
- `corepack yarn workspace @mondaydotcomorg/api test --runInBand`
- `./node_modules/.bin/prettier.cmd --check packages/api/package.json packages/api/rollup.config.js`
- `git diff --check -- packages/api/package.json packages/api/rollup.config.js`

Implemented with Codex assistance; I kept the patch focused and manually verified the package-name import path that fails in the issue.
