### PR TITLE
Update default API version to 2026-04

### DIFF
--- a/packages/api/CHANGELOG.MD
+++ b/packages/api/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Changelog
 
+## [15.0.0]
+
+### ⚠️ Breaking Changes
+
+- **Default API version updated**: The default API version is now `2026-04`
+
 ## [14.0.0]
 
 ### ⚠️ Breaking Changes

--- a/packages/api/lib/constants/index.ts
+++ b/packages/api/lib/constants/index.ts
@@ -4,7 +4,7 @@ export enum AvailableVersions {
   CURRENT = 'current',
   RELEASE_CANDIDATE = 'release_candidate',
   DEV = 'dev',
-  CURRENT_VERSION = '2026-01',
+  CURRENT_VERSION = '2026-04',
 }
 
 export const MONDAY_API_ENDPOINT = 'https://api.monday.com/v2';

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/api",
-  "version": "14.0.0",
+  "version": "15.0.0",
   "description": "monday.com API client",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Bumps the SDK's default API version from `2026-01` to `2026-04` (the current monday.com API version), following the established quarterly version-bump convention.

## Changes

- **`lib/constants/index.ts`** — `CURRENT_VERSION`: `2026-01` → `2026-04`
- **`package.json`** — `14.0.0` → `15.0.0`
- **`CHANGELOG.MD`** — new `[15.0.0]` entry

## Why a major bump

Changing the default `API-Version` header is a behavior change for consumers that don't pin a version, so it's released as a major — consistent with the prior default-version bumps (`11.0.0` → 2025-07, `12.0.0` → 2025-10, `13.0.0` → 2026-01) and with the quarterly update workflow (`yarn version --new-version major`).

## Scope notes

- **Generated code left untouched.** `lib/generated/sdk.ts` and `@mondaydotcomorg/api-types` are produced by monday's SDK generator and, per the repo README, aren't modified in PRs. This mirrors the previous bump (`6802d43`), which changed only these same three files.
- **2026-04 is additive.** Per the [changelog](https://developer.monday.com/api-reference/changelog), 2026-04 adds capabilities (e.g. `object_relations`, `notetaker.meetings`, document version-history queries, new `ExternalWidget` enum members) with no removed or renamed fields, so existing typed queries are unaffected by the new default.
- **No validation change needed.** The existing `^\d{4}-(01|04|07|10)$` check already accepts `2026-04`; `versionOverride: '2026-04'` has worked since before this PR.
- **`setup-api` unaffected.** It fetches the schema with `version=current`, which tracks the current version automatically.

## Testing

- `yarn build` ✅
- `yarn test` ✅ (33/33)
- `yarn lint` ✅

Existing tests assert the `API-Version` header via the `DEFAULT_VERSION` constant rather than a literal, so they continue to pass against the new default.
